### PR TITLE
Fix rocAL Tensor build issues - Augmentation nodes and OpenVX fix

### DIFF
--- a/amd_openvx_extensions/amd_rpp/source/Brightness.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/Brightness.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "internal_publishKernels.h"
 
 struct BrightnessLocalData {
-    RPPCommonHandle * handle;
+    vxRppHandle * handle;
     Rpp32u deviceType;
     RppPtr_t pSrc;
     RppPtr_t pDst;
@@ -177,7 +177,7 @@ static vx_status VX_CALLBACK initializeBrightness(vx_node node, const vx_referen
     data->alpha = (vx_float32 *)malloc(sizeof(vx_float32) * data->srcDescPtr->n);
     data->beta = (vx_float32 *)malloc(sizeof(vx_float32) * data->srcDescPtr->n);
     refreshBrightness(node, parameters, num, data);
-    STATUS_ERROR_CHECK(createGraphHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
+    STATUS_ERROR_CHECK(createRPPHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
     STATUS_ERROR_CHECK(vxSetNodeAttribute(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     return VX_SUCCESS;
 }
@@ -185,7 +185,7 @@ static vx_status VX_CALLBACK initializeBrightness(vx_node node, const vx_referen
 static vx_status VX_CALLBACK uninitializeBrightness(vx_node node, const vx_reference *parameters, vx_uint32 num) {
     BrightnessLocalData *data;
     STATUS_ERROR_CHECK(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
-    STATUS_ERROR_CHECK(releaseGraphHandle(node, data->handle, data->deviceType));
+    STATUS_ERROR_CHECK(releaseRPPHandle(node, data->handle, data->deviceType));
     free(data->alpha);
     free(data->beta);
     delete (data);

--- a/amd_openvx_extensions/amd_rpp/source/Copy.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/Copy.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 struct CopyLocalData
 {
-    RPPCommonHandle handle;
+    vxRppHandle handle;
     Rpp32u device_type;
     RppPtr_t pSrc;
     RppPtr_t pDst;

--- a/amd_openvx_extensions/amd_rpp/source/CropMirrorNormalize.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/CropMirrorNormalize.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "internal_publishKernels.h"
 
 struct CropMirrorNormalizeLocalData {
-    RPPCommonHandle * handle;
+    vxRppHandle * handle;
     Rpp32u deviceType;
     RppPtr_t pSrc;
     RppPtr_t pDst;
@@ -188,7 +188,7 @@ static vx_status VX_CALLBACK initializeCropMirrorNormalize(vx_node node, const v
     data->offset = (vx_float32 *)malloc(sizeof(vx_float32) * data->srcDescPtr->n * data->srcDescPtr->c);
     data->mirror = (vx_uint32 *)malloc(sizeof(vx_uint32) * data->srcDescPtr->n);
     refreshCropMirrorNormalize(node, parameters, num, data);
-    STATUS_ERROR_CHECK(createGraphHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
+    STATUS_ERROR_CHECK(createRPPHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
     STATUS_ERROR_CHECK(vxSetNodeAttribute(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     return VX_SUCCESS;
 }
@@ -196,7 +196,7 @@ static vx_status VX_CALLBACK initializeCropMirrorNormalize(vx_node node, const v
 static vx_status VX_CALLBACK uninitializeCropMirrorNormalize(vx_node node, const vx_reference *parameters, vx_uint32 num) {
     CropMirrorNormalizeLocalData *data;
     STATUS_ERROR_CHECK(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
-    STATUS_ERROR_CHECK(releaseGraphHandle(node, data->handle, data->deviceType));
+    STATUS_ERROR_CHECK(releaseRPPHandle(node, data->handle, data->deviceType));
     free(data->multiplier);
     free(data->offset);
     free(data->mirror);

--- a/amd_openvx_extensions/amd_rpp/source/Nop.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/Nop.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 struct NopLocalData
 {
-    RPPCommonHandle handle;
+    vxRppHandle handle;
     Rpp32u device_type;
     RppPtr_t pSrc;
     RppPtr_t pDst;

--- a/amd_openvx_extensions/amd_rpp/source/SequenceRearrange.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/SequenceRearrange.cpp
@@ -178,7 +178,7 @@ static vx_status VX_CALLBACK initializeSequenceRearrange(vx_node node, const vx_
     data->newSequenceLength = out_tensor_dims[1];
     data->newOrder = (vx_uint32 *)malloc(sizeof(vx_uint32) * data->newSequenceLength);
     refreshSequenceRearrange(node, parameters, num, data);
-    STATUS_ERROR_CHECK(createGraphHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
+    STATUS_ERROR_CHECK(createRPPHandle(node, &data->handle, data->srcDescPtr->n, data->deviceType));
     STATUS_ERROR_CHECK(vxSetNodeAttribute(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 
     return VX_SUCCESS;
@@ -187,7 +187,7 @@ static vx_status VX_CALLBACK initializeSequenceRearrange(vx_node node, const vx_
 static vx_status VX_CALLBACK uninitializeSequenceRearrange(vx_node node, const vx_reference *parameters, vx_uint32 num) {
     SequenceRearrangeLocalData *data;
     STATUS_ERROR_CHECK(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
-    STATUS_ERROR_CHECK(releaseGraphHandle(node, data->handle, data->deviceType));
+    STATUS_ERROR_CHECK(releaseRPPHandle(node, data->handle, data->deviceType));
     if(data->newOrder) free(data->newOrder);
     delete (data);
     return VX_SUCCESS;

--- a/amd_openvx_extensions/amd_rpp/source/internal_publishKernels.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/internal_publishKernels.cpp
@@ -126,6 +126,10 @@ vx_status get_kernels_to_publish()
     STATUS_ERROR_CHECK(ADD_KERNEL(ResizeMirrorNormalizeTensor_Register));
     STATUS_ERROR_CHECK(ADD_KERNEL(SequenceRearrange_Register));
     STATUS_ERROR_CHECK(ADD_KERNEL(Resizetensor_Register));
+    STATUS_ERROR_CHECK(ADD_KERNEL(Brightness_Register));
+    STATUS_ERROR_CHECK(ADD_KERNEL(CropMirrorNormalize_Register));
+    STATUS_ERROR_CHECK(ADD_KERNEL(Copy_Register));
+    STATUS_ERROR_CHECK(ADD_KERNEL(Nop_Register));
     return status;
 }
 

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_blend.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_blend.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 class BlendNode : public Node
 {
 public:
-    explicit BlendNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    explicit BlendNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     BlendNode() = delete;
 
     void init(float ratio);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_blur.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_blur.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class BlurNode : public Node
 {
 public:
-    BlurNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    BlurNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     BlurNode() = delete;
     void init(int sdev);
     void init(IntParam *sdev);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_color_temperature.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_color_temperature.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class ColorTemperatureNode : public Node
 {
 public:
-    ColorTemperatureNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ColorTemperatureNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
 
     ColorTemperatureNode() = delete;
     void init(int adjustment);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_color_twist.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_color_twist.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class ColorTwistBatchNode : public Node
 {
 public:
-    ColorTwistBatchNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ColorTwistBatchNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     ColorTwistBatchNode() = delete;
     void init(float alpha, float beta, float hue, float sat);
     void init(FloatParam *alpha, FloatParam *beta, FloatParam *hue, FloatParam *sat);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_contrast.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_contrast.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class RocalContrastNode : public Node
 {
 public:
-    RocalContrastNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    RocalContrastNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     RocalContrastNode() = delete;
     void init(int min, int max);
     void init(IntParam *min, IntParam * max);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_exposure.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_exposure.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class ExposureNode : public Node
 {
 public:
-    ExposureNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ExposureNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     ExposureNode() = delete;
     void init(float shift);
     void init(FloatParam *shift);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_gamma.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_gamma.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class GammaNode : public Node
 {
 public:
-    GammaNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    GammaNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     GammaNode() = delete;
     void init(float shift);
     void init(FloatParam *shift);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_hue.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_hue.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class HueNode : public Node
 {
 public:
-    HueNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    HueNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     HueNode() = delete;
     void init(float hue);
     void init(FloatParam *hue);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_saturation.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_saturation.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class SatNode : public Node
 {
 public:
-    SatNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    SatNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     SatNode() = delete;
     void init(float sat);
     void init(FloatParam *sat);

--- a/rocAL/rocAL/include/augmentations/color_augmentations/node_vignette.h
+++ b/rocAL/rocAL/include/augmentations/color_augmentations/node_vignette.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class VignetteNode : public Node
 {
 public:
-    VignetteNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    VignetteNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     VignetteNode () = delete;
     void init(float sdev);
     void init(FloatParam *sdev);

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_fog.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_fog.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 class FogNode : public Node
 {
 public:
-    FogNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    FogNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     FogNode() = delete;
     void init(float fog_param);
     void init(FloatParam *fog_param);

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_jitter.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_jitter.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class JitterNode : public Node
 {
 public:
-    JitterNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    JitterNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     JitterNode() = delete;
     void init(int kernel_size);
     void init(IntParam *kernel_size);

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_pixelate.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_pixelate.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 class PixelateNode : public Node
 {
 public:
-    PixelateNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    PixelateNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     PixelateNode() = delete;
 protected:
     void create_node() override;

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_rain.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_rain.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class RainNode : public Node
 {
 public:
-    RainNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    RainNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     RainNode() = delete;
     void init(float rain_value, int rain_width, int rain_height, float rain_transparency);
     void init(FloatParam *rain_value, IntParam *rain_width, IntParam *rain_height, FloatParam *rain_transparency); 

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_snow.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_snow.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class SnowNode : public Node
 {
 public:
-    SnowNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    SnowNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     SnowNode() = delete;
     void init(float shift);
     void init(FloatParam *shift);

--- a/rocAL/rocAL/include/augmentations/effects_augmentations/node_snp_noise.h
+++ b/rocAL/rocAL/include/augmentations/effects_augmentations/node_snp_noise.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 class SnPNoiseNode : public Node
 {
 public:
-    SnPNoiseNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    SnPNoiseNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     SnPNoiseNode() = delete;
     void init(float sdev);
     void init(FloatParam *sdev);

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_crop.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_crop.h
@@ -29,13 +29,13 @@ THE SOFTWARE.
 class CropNode : public Node
 {
 public:
-    CropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    CropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     CropNode() = delete;
     void init(unsigned int crop_h, unsigned int crop_w, float x_drift, float y_drift);
     void init(unsigned int crop_h, unsigned int crop_w);
     void init( FloatParam *crop_h_factor, FloatParam *crop_w_factor, FloatParam * x_drift, FloatParam * y_drift);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     std::shared_ptr<RocalCropParam> get_crop_param() { return _crop_param; }
 protected:
     void create_node() override ;

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_crop_resize.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_crop_resize.h
@@ -28,12 +28,12 @@ THE SOFTWARE.
 class CropResizeNode : public Node
 {
 public:
-    CropResizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    CropResizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     CropResizeNode() = delete;
     void init(float area, float aspect_ratio, float x_center_drift, float y_center_drift);
     void init(FloatParam* area, FloatParam *aspect_ratio, FloatParam * x_drift_factor, FloatParam * y_drift_factor);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     std::shared_ptr<RocalRandomCropParam> get_crop_param() { return _crop_param; }
 protected:
     void create_node() override;

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_fisheye.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_fisheye.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class FisheyeNode : public Node
 {
 public:
-    FisheyeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    FisheyeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     FisheyeNode() = delete;
 
 protected:

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_flip.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_flip.h
@@ -28,12 +28,12 @@ THE SOFTWARE.
 class FlipNode : public Node
 {
 public:
-    FlipNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    FlipNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     FlipNode() = delete;
     void init(int flip_axis);
     void init(IntParam *flip_axis);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     vx_array get_src_width() { return _src_roi_width; }
     vx_array get_src_height() { return _src_roi_height; }
     vx_array get_flip_axis() { return _flip_axis.default_array(); }

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_lens_correction.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_lens_correction.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 class LensCorrectionNode : public Node
 {
 public:
-    LensCorrectionNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    LensCorrectionNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     LensCorrectionNode() = delete;
     void init(float strength, float zoom);
     void init(FloatParam *strength, FloatParam *zoom);

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_random_crop.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_random_crop.h
@@ -28,12 +28,12 @@ THE SOFTWARE.
 class RandomCropNode : public Node
 {
 public:
-    RandomCropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    RandomCropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     RandomCropNode() = delete;
     void init(float area, float aspect_ratio, float x_drift, float y_drift);
     void init(FloatParam *crop_area_factor, FloatParam *crop_aspect_ratio, FloatParam *x_drift, FloatParam *y_drift, int num_of_attempts);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     std::shared_ptr<RocalRandomCropParam> get_crop_param() { return _crop_param; }
     int get_num_of_attempts(){return _num_of_attempts;}
 

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize.h
@@ -26,10 +26,10 @@ THE SOFTWARE.
 
 class ResizeNode : public Node {
 public:
-    ResizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ResizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     ResizeNode() = delete;
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     vx_array get_src_width() { return _src_roi_width; }
     vx_array get_src_height() { return _src_roi_height; }
     void init(unsigned dest_width, unsigned dest_height, RocalResizeScalingMode scaling_mode,

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize_crop_mirror.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize_crop_mirror.h
@@ -31,12 +31,12 @@ class CropParam;
 class ResizeCropMirrorNode : public Node
 {
 public:
-    ResizeCropMirrorNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ResizeCropMirrorNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     ResizeCropMirrorNode() = delete;
     void init(unsigned int crop_h, unsigned int crop_w, IntParam *mirror);
     void init( FloatParam *crop_h_factor, FloatParam *crop_w_factor, IntParam *mirror);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     std::shared_ptr<RocalCropParam> get_crop_param() { return _crop_param; }
     vx_array get_mirror() { return _mirror.default_array(); }
 protected:

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize_mirror_normalize.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_resize_mirror_normalize.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 class ResizeMirrorNormalizeNode : public Node
 {
 public:
-    ResizeMirrorNormalizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    ResizeMirrorNormalizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     ResizeMirrorNormalizeNode() = delete;
     void init(std::vector<float>& mean,  std::vector<float>& std_dev, IntParam *mirror);
     vx_array get_dst_width() { return _dst_roi_width; }

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_rotate.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_rotate.h
@@ -29,12 +29,12 @@ THE SOFTWARE.
 class RotateNode : public Node
 {
 public:
-    RotateNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    RotateNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     RotateNode() = delete;
     void init(float angle);
     void init(FloatParam *angle);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     vx_array get_src_width() { return _src_roi_width; }
     vx_array get_src_height() { return _src_roi_height; }
     vx_array get_angle() { return _angle.default_array(); }

--- a/rocAL/rocAL/include/augmentations/geometry_augmentations/node_warp_affine.h
+++ b/rocAL/rocAL/include/augmentations/geometry_augmentations/node_warp_affine.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 class WarpAffineNode : public Node
 {
 public:
-    WarpAffineNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    WarpAffineNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     WarpAffineNode() = delete;
     void init(float x0, float x1, float y0, float y1, float o0, float o1);
     void init(FloatParam* x0, FloatParam* x1, FloatParam* y0, FloatParam* y1, FloatParam* o0, FloatParam* o1);

--- a/rocAL/rocAL/include/augmentations/node_copy.h
+++ b/rocAL/rocAL/include/augmentations/node_copy.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 class CopyNode : public Node
 {
 public:
-    CopyNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    CopyNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     CopyNode() = delete;
 
 protected:

--- a/rocAL/rocAL/include/augmentations/node_nop.h
+++ b/rocAL/rocAL/include/augmentations/node_nop.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 class NopNode : public Node
 {
 public:
-    NopNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    NopNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     NopNode() = delete;
 protected:
     void create_node() override;

--- a/rocAL/rocAL/include/augmentations/node_ssd_random_crop.h
+++ b/rocAL/rocAL/include/augmentations/node_ssd_random_crop.h
@@ -62,11 +62,11 @@ private:
 class SSDRandomCropNode : public Node
 {
 public:
-    SSDRandomCropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs);
+    SSDRandomCropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
     SSDRandomCropNode() = delete;
     void init(FloatParam *crop_area_factor, FloatParam *crop_aspect_ratio, FloatParam *x_drift, FloatParam *y_drift, int num_of_attempts);
-    unsigned int get_dst_width() { return _outputs[0]->info().width(); }
-    unsigned int get_dst_height() { return _outputs[0]->info().height_single(); }
+    unsigned int get_dst_width() { return _outputs[0]->info().max_shape()[0]; }
+    unsigned int get_dst_height() { return _outputs[0]->info().max_shape()[1]; }
     std::shared_ptr<RocalRandomCropParam> get_crop_param() { return _crop_param; }
     float get_threshold(){return _threshold;}
     std::vector<std::pair<float,float>> get_iou_range(){return _iou_range;}

--- a/rocAL/rocAL/include/pipeline/node.h
+++ b/rocAL/rocAL/include/pipeline/node.h
@@ -54,4 +54,5 @@ protected:
     vx_node _node = nullptr;
     size_t _batch_size;
     pMetaDataBatch _meta_data_info;
+    vx_array _src_roi_width, _src_roi_height; // TODO - To be removed after tensor changes in augmentation nodes.
 };

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_blend.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_blend.cpp
@@ -41,7 +41,7 @@ void BlendNode::create_node()
         THROW("Blend node needs two input images")
 
     _ratio.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_BlendbatchPD(_graph->get(), _inputs[0]->handle(), _inputs[1]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _ratio.default_array(), _batch_size);
+    // _node = vxExtrppNode_BlendbatchPD(_graph->get(), _inputs[0]->handle(), _inputs[1]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _ratio.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_blend.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_blend.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-BlendNode::BlendNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+BlendNode::BlendNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _ratio(RATIO_RANGE[0], RATIO_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_blur.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_blur.cpp
@@ -36,7 +36,7 @@ void BlurNode::create_node()
         return;
 
     _sdev.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
-    _node = vxExtrppNode_BlurbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width,_src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
+    // _node = vxExtrppNode_BlurbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width,_src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_blur.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_blur.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_blur.h"
 #include "exception.h"
 
-BlurNode::BlurNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+BlurNode::BlurNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _sdev(SDEV_RANGE[0], SDEV_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_color_temperature.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_color_temperature.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_color_temperature.h"
 #include "exception.h"
 
-ColorTemperatureNode::ColorTemperatureNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ColorTemperatureNode::ColorTemperatureNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _adj_value_param(ADJUSTMENT_RANGE[0], ADJUSTMENT_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_color_temperature.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_color_temperature.cpp
@@ -38,7 +38,7 @@ void ColorTemperatureNode::create_node()
 
     _adj_value_param.create_array(_graph , VX_TYPE_INT32, _batch_size);
 
-    _node = vxExtrppNode_ColorTemperaturebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _adj_value_param.default_array(), _batch_size);
+    // _node = vxExtrppNode_ColorTemperaturebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _adj_value_param.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_color_twist.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_color_twist.cpp
@@ -45,7 +45,7 @@ void ColorTwistBatchNode::create_node()
     _hue.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
     _sat.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
 
-    _node = vxExtrppNode_ColorTwistbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _alpha.default_array(), _beta.default_array(), _hue.default_array(), _sat.default_array(), _batch_size);/*A temporary fix for time being*/
+    // _node = vxExtrppNode_ColorTwistbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _alpha.default_array(), _beta.default_array(), _hue.default_array(), _sat.default_array(), _batch_size);/*A temporary fix for time being*/
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_color_twist.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_color_twist.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-ColorTwistBatchNode::ColorTwistBatchNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ColorTwistBatchNode::ColorTwistBatchNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _alpha(ALPHA_RANGE[0], ALPHA_RANGE[1]),
         _beta (BETA_RANGE[0], BETA_RANGE[1]),

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_contrast.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_contrast.cpp
@@ -40,7 +40,7 @@ void RocalContrastNode::create_node()
     _min.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
     _max.create_array(_graph ,VX_TYPE_UINT32 , _batch_size);
 
-    _node = vxExtrppNode_ContrastbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _min.default_array(), _max.default_array(), _batch_size);
+    // _node = vxExtrppNode_ContrastbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _min.default_array(), _max.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_contrast.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_contrast.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_contrast.h"
 #include "exception.h"
 
-RocalContrastNode::RocalContrastNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+RocalContrastNode::RocalContrastNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _min(CONTRAST_MIN_RANGE[0], CONTRAST_MIN_RANGE[1]),
         _max(CONTRAST_MAX_RANGE[0], CONTRAST_MAX_RANGE[1])

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_exposure.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_exposure.cpp
@@ -36,7 +36,7 @@ void ExposureNode::create_node()
         return;
 
     _shift.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_ExposurebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
+    // _node = vxExtrppNode_ExposurebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_exposure.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_exposure.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_exposure.h"
 #include "exception.h"
 
-ExposureNode::ExposureNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ExposureNode::ExposureNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _shift(SHIFT_RANGE[0], SHIFT_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_gamma.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_gamma.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-GammaNode::GammaNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+GammaNode::GammaNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _shift(SHIFT_RANGE[0], SHIFT_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_gamma.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_gamma.cpp
@@ -42,7 +42,7 @@ void GammaNode::create_node()
         THROW("Uninitialized input/output arguments")
 
     _shift.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_GammaCorrectionbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
+    // _node = vxExtrppNode_GammaCorrectionbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_hue.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_hue.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-HueNode::HueNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+HueNode::HueNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _hue(HUE_RANGE[0], HUE_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_hue.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_hue.cpp
@@ -39,7 +39,7 @@ void HueNode::create_node()
         return;
 
     _hue.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_HuebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _hue.default_array(), _batch_size);
+    // _node = vxExtrppNode_HuebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _hue.default_array(), _batch_size);
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
         THROW("Adding the Hue (vxExtrppNode_HueCorrectionbatchPD) node failed: "+ TOSTR(status))

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_saturation.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_saturation.cpp
@@ -38,7 +38,7 @@ void SatNode::create_node()
     if(_node)
         return;
     _sat.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_SaturationbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sat.default_array(), _batch_size);
+    // _node = vxExtrppNode_SaturationbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sat.default_array(), _batch_size);
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
         THROW("Adding the Saturation (vxExtrppNodeSaturationbatchPD) node failed: "+ TOSTR(status))

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_saturation.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_saturation.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-SatNode::SatNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+SatNode::SatNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _sat(SAT_RANGE[0], SAT_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_vignette.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_vignette.cpp
@@ -38,7 +38,7 @@ void VignetteNode::create_node()
 
     _sdev.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
 
-    _node = vxExtrppNode_VignettebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
+    // _node = vxExtrppNode_VignettebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/color_augmentations/node_vignette.cpp
+++ b/rocAL/rocAL/source/augmentations/color_augmentations/node_vignette.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_vignette.h"
 #include "exception.h"
 
-VignetteNode::VignetteNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+VignetteNode::VignetteNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _sdev(SDEV_RANGE[0], SDEV_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_fog.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_fog.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_fog.h"
 #include "exception.h"
 
-FogNode::FogNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+FogNode::FogNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _fog_param(FOG_VALUE_RANGE[0], FOG_VALUE_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_fog.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_fog.cpp
@@ -37,7 +37,7 @@ void FogNode::create_node()
         return;
 
     _fog_param.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_FogbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _fog_param.default_array(), _batch_size);
+    // _node = vxExtrppNode_FogbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _fog_param.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_jitter.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_jitter.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-JitterNode::JitterNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+JitterNode::JitterNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _kernel_size(KERNEL_SIZE[0], KERNEL_SIZE[1])
 {

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_jitter.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_jitter.cpp
@@ -38,7 +38,7 @@ void JitterNode::create_node()
         return;
 
     _kernel_size.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
-    _node = vxExtrppNode_JitterbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _kernel_size.default_array(), _batch_size);
+    // _node = vxExtrppNode_JitterbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _kernel_size.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_pixelate.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_pixelate.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <graph.h>
 #include "exception.h"
 
-PixelateNode::PixelateNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+PixelateNode::PixelateNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs)
 {
 }

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_pixelate.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_pixelate.cpp
@@ -35,7 +35,7 @@ void PixelateNode::create_node()
     if(_node)
         return;
 
-    _node = vxExtrppNode_PixelatebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _batch_size);
+    // _node = vxExtrppNode_PixelatebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_rain.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_rain.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "node_rain.h"
 #include "exception.h"
 
-RainNode::RainNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+RainNode::RainNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _rain_value(RAIN_VALUE_RANGE[0], RAIN_VALUE_RANGE[1]),
         _rain_width(RAIN_WIDTH_RANGE[0],RAIN_WIDTH_RANGE[1]),

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_rain.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_rain.cpp
@@ -44,8 +44,8 @@ void RainNode::create_node()
     _rain_transparency.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
     _rain_width.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
     _rain_height.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
-    _node = vxExtrppNode_RainbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _rain_value.default_array(), _rain_width.default_array(),
-                                                    _rain_height.default_array(), _rain_transparency.default_array(), _batch_size);
+    // _node = vxExtrppNode_RainbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _rain_value.default_array(), _rain_width.default_array(),
+                                                    // _rain_height.default_array(), _rain_transparency.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_snow.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_snow.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-SnowNode::SnowNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+SnowNode::SnowNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _shift(SNOW_VALUE_RANGE[0], SNOW_VALUE_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_snow.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_snow.cpp
@@ -38,7 +38,7 @@ void SnowNode::create_node()
         return;
 
     _shift.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_SnowbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
+    // _node = vxExtrppNode_SnowbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _shift.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_snp_noise.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_snp_noise.cpp
@@ -38,7 +38,7 @@ void SnPNoiseNode::create_node()
         return;
 
     _sdev.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_NoisebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
+    // _node = vxExtrppNode_NoisebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _sdev.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/effects_augmentations/node_snp_noise.cpp
+++ b/rocAL/rocAL/source/augmentations/effects_augmentations/node_snp_noise.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-SnPNoiseNode::SnPNoiseNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+SnPNoiseNode::SnPNoiseNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _sdev(SDEV_RANGE[0], SDEV_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "parameter_crop.h"
 #include "exception.h"
 
-CropNode::CropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+CropNode::CropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _dest_width(_outputs[0]->info().width()),
         _dest_height(_outputs[0]->info().height_batch())

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 
 CropNode::CropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
-        _dest_width(_outputs[0]->info().width()),
-        _dest_height(_outputs[0]->info().height_batch())
+        _dest_width(_outputs[0]->info().max_shape()[0]),
+        _dest_height(_outputs[0]->info().max_shape()[1])
 {
     _crop_param = std::make_shared<RocalCropParam>(_batch_size);
 }
@@ -44,8 +44,8 @@ void CropNode::create_node()
 
     _crop_param->create_array(_graph);
 
-    _node = vxExtrppNode_CropPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _crop_param->cropw_arr,
-                                _crop_param->croph_arr, _crop_param->x1_arr, _crop_param->y1_arr, _batch_size);
+    // _node = vxExtrppNode_CropPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _crop_param->cropw_arr,
+                                // _crop_param->croph_arr, _crop_param->x1_arr, _crop_param->y1_arr, _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
@@ -54,11 +54,11 @@ void CropNode::create_node()
 
 void CropNode::update_node()
 {
-    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi_width_vec(), _inputs[0]->info().get_roi_height_vec());
+    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi());
     _crop_param->update_array();
     std::vector<uint32_t> crop_h_dims, crop_w_dims;
     _crop_param->get_crop_dimensions(crop_w_dims, crop_h_dims);
-    _outputs[0]->update_image_roi(crop_w_dims, crop_h_dims);
+    _outputs[0]->update_tensor_roi(crop_w_dims, crop_h_dims);
 }
 
 void CropNode::init(unsigned int crop_h, unsigned int crop_w, float x_drift_, float y_drift_)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop_resize.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_crop_resize.h"
 #include "exception.h"
 
-CropResizeNode::CropResizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+CropResizeNode::CropResizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _dest_width(_outputs[0]->info().width()),
         _dest_height(_outputs[0]->info().height_batch())

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_crop_resize.cpp
@@ -27,8 +27,8 @@ THE SOFTWARE.
 
 CropResizeNode::CropResizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
-        _dest_width(_outputs[0]->info().width()),
-        _dest_height(_outputs[0]->info().height_batch())
+        _dest_width(_outputs[0]->info().max_shape()[0]),
+        _dest_height(_outputs[0]->info().max_shape()[1])
 {
     _crop_param = std::make_shared<RocalRandomCropParam>(_batch_size);
 }
@@ -43,8 +43,8 @@ void CropResizeNode::create_node()
 
     _crop_param->create_array(_graph);
 
-    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().width());
-    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().height_single());
+    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().max_shape()[0]);
+    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().max_shape()[1]);
 
     _dst_roi_width = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
     _dst_roi_height = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
@@ -56,8 +56,8 @@ void CropResizeNode::create_node()
     if(width_status != 0 || height_status != 0)
         THROW(" vxAddArrayItems failed in the crop resize node (vxExtrppNode_ResizeCropbatchPD    )  node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
 
-    _node = vxExtrppNode_ResizeCropbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width,
-                                           _dst_roi_height, _crop_param->x1_arr, _crop_param->y1_arr, _crop_param->x2_arr, _crop_param->y2_arr, _batch_size);
+    // _node = vxExtrppNode_ResizeCropbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width,
+                                        //    _dst_roi_height, _crop_param->x1_arr, _crop_param->y1_arr, _crop_param->x2_arr, _crop_param->y2_arr, _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
@@ -66,7 +66,7 @@ void CropResizeNode::create_node()
 
 void CropResizeNode::update_node()
 {
-    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi_width_vec(), _inputs[0]->info().get_roi_height_vec());
+    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi());
     _crop_param->update_array();
 }
 

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_fisheye.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_fisheye.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_fisheye.h"
 #include "exception.h"
 
-FisheyeNode::FisheyeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+FisheyeNode::FisheyeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs)
 {
 }

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_fisheye.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_fisheye.cpp
@@ -34,7 +34,7 @@ void FisheyeNode::create_node()
     if(_node)
         return;
     
-    _node = vxExtrppNode_FisheyebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _batch_size);
+    // _node = vxExtrppNode_FisheyebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_flip.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_flip.cpp
@@ -38,7 +38,7 @@ void FlipNode::create_node()
 
 
     _flip_axis.create_array(_graph ,VX_TYPE_UINT32 ,_batch_size);
-    _node = vxExtrppNode_FlipbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _flip_axis.default_array(), _batch_size);
+    // _node = vxExtrppNode_FlipbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _flip_axis.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_flip.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_flip.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_flip.h"
 #include "exception.h"
 
-FlipNode::FlipNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+FlipNode::FlipNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _flip_axis(FLIP_SIZE[0], FLIP_SIZE[1])
 {

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_lens_correction.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_lens_correction.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-LensCorrectionNode::LensCorrectionNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+LensCorrectionNode::LensCorrectionNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _strength(STRENGTH_RANGE[0], STRENGTH_RANGE[1]),
         _zoom(ZOOM_RANGE[0], ZOOM_RANGE[1])

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_lens_correction.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_lens_correction.cpp
@@ -41,7 +41,7 @@ void LensCorrectionNode::create_node()
 
     _strength.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
     _zoom.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-    _node = vxExtrppNode_LensCorrectionbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _strength.default_array(), _zoom.default_array(), _batch_size);
+    // _node = vxExtrppNode_LensCorrectionbatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _strength.default_array(), _zoom.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_random_crop.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_random_crop.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_random_crop.h"
 #include "exception.h"
 
-RandomCropNode::RandomCropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+RandomCropNode::RandomCropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _dest_width(_outputs[0]->info().width()),
         _dest_height(_outputs[0]->info().height_batch())

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_random_crop.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_random_crop.cpp
@@ -27,8 +27,8 @@ THE SOFTWARE.
 
 RandomCropNode::RandomCropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
-        _dest_width(_outputs[0]->info().width()),
-        _dest_height(_outputs[0]->info().height_batch())
+        _dest_width(_outputs[0]->info().max_shape()[0]),
+        _dest_height(_outputs[0]->info().max_shape()[1])
 {
     _crop_param = std::make_shared<RocalRandomCropParam>(_batch_size);
 }
@@ -42,8 +42,8 @@ void RandomCropNode::create_node()
         THROW("Uninitialized destination dimension")
 
     _crop_param->create_array(_graph);
-    _node = vxExtrppNode_CropPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _crop_param->cropw_arr,
-                                _crop_param->croph_arr, _crop_param->x1_arr, _crop_param->y1_arr, _batch_size);
+    // _node = vxExtrppNode_CropPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _crop_param->cropw_arr,
+                                // _crop_param->croph_arr, _crop_param->x1_arr, _crop_param->y1_arr, _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
@@ -52,11 +52,11 @@ void RandomCropNode::create_node()
 
 void RandomCropNode::update_node()
 {
-    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi_width_vec(), _inputs[0]->info().get_roi_height_vec());
+    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi());
     _crop_param->update_array();
     std::vector<uint32_t> crop_h_dims, crop_w_dims;
     _crop_param->get_crop_dimensions(crop_w_dims, crop_h_dims);
-    _outputs[0]->update_image_roi(crop_w_dims, crop_h_dims);
+    _outputs[0]->update_tensor_roi(crop_w_dims, crop_h_dims);
 }
 
 void RandomCropNode::init(float crop_area_factor, float crop_aspect_ratio, float x_drift, float y_drift)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-ResizeNode::ResizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ResizeNode::ResizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs)
 {
 }

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -61,16 +61,16 @@ void ResizeNode::create_node() {
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
     // Using original width and height instead of the decoded width and height for computing resize dimensions
-    src_w_dims = _inputs[0]->info().get_orig_roi_width_vec();
-    src_h_dims = _inputs[0]->info().get_orig_roi_height_vec();
+    src_w_dims = _inputs[0]->info().get_original_roi_width_vec();
+    src_h_dims = _inputs[0]->info().get_original_roi_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];
         _dst_width = _out_width;
         _dst_height = _out_height;
         adjust_out_roi_size();
-        _dst_width = std::min(_dst_width, (unsigned)_outputs[0]->info().max_shape()[0]);
-        _dst_height = std::min(_dst_height, (unsigned)_outputs[0]->info().max_shape()[1]);
+        _dst_width = std::min(_dst_width, static_cast<unsigned>(_outputs[0]->info().max_shape()[0]));
+        _dst_height = std::min(_dst_height, static_cast<unsigned>(_outputs[0]->info().max_shape()[1]));
         _dst_roi_width_vec.push_back(_dst_width);
         _dst_roi_height_vec.push_back(_dst_height);
     }

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -35,8 +35,8 @@ void ResizeNode::create_node() {
     if(_node)
         return;
 
-    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().width());
-    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().height_single());
+    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().max_shape()[0]);
+    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().max_shape()[1]);
 
     _dst_roi_width = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
     _dst_roi_height = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
@@ -49,9 +49,9 @@ void ResizeNode::create_node() {
         THROW(" vxAddArrayItems failed in the resize (vxExtrppNode_ResizebatchPD) node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
 #if ENABLE_OPENCL
     // fall back to batch_pd version since there is no tensor implementation for OPENCL    
-    _node = vxExtrppNode_ResizebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _batch_size);
+    // _node = vxExtrppNode_ResizebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _batch_size);
 #else
-   _node = vxExtrppNode_Resizetensor(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _interpolation_type, _batch_size);
+   // _node = vxExtrppNode_Resizetensor(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _interpolation_type, _batch_size);
 #endif
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
@@ -61,16 +61,16 @@ void ResizeNode::create_node() {
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
     // Using original width and height instead of the decoded width and height for computing resize dimensions
-    src_w_dims = _inputs[0]->info().get_original_width_vec();
-    src_h_dims = _inputs[0]->info().get_original_height_vec();
+    src_w_dims = _inputs[0]->info().get_orig_roi_width_vec();
+    src_h_dims = _inputs[0]->info().get_orig_roi_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];
         _dst_width = _out_width;
         _dst_height = _out_height;
         adjust_out_roi_size();
-        _dst_width = std::min(_dst_width, _outputs[0]->info().width());
-        _dst_height = std::min(_dst_height, _outputs[0]->info().height_single());
+        _dst_width = std::min(_dst_width, (unsigned)_outputs[0]->info().max_shape()[0]);
+        _dst_height = std::min(_dst_height, (unsigned)_outputs[0]->info().max_shape()[1]);
         _dst_roi_width_vec.push_back(_dst_width);
         _dst_roi_height_vec.push_back(_dst_height);
     }
@@ -79,7 +79,7 @@ void ResizeNode::update_node() {
     height_status = vxCopyArrayRange((vx_array)_dst_roi_height, 0, _batch_size, sizeof(vx_uint32), _dst_roi_height_vec.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
     if(width_status != 0 || height_status != 0)
         WRN("ERROR: vxCopyArrayRange _dst_roi_width or _dst_roi_height failed " + TOSTR(width_status) + "  " + TOSTR(height_status));
-    _outputs[0]->update_image_roi(_dst_roi_width_vec, _dst_roi_height_vec);
+    _outputs[0]->update_tensor_roi(_dst_roi_width_vec, _dst_roi_height_vec);
     _dst_roi_width_vec.clear();
     _dst_roi_height_vec.clear();
 }

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_crop_mirror.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_crop_mirror.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_resize_crop_mirror.h"
 #include "exception.h"
 
-ResizeCropMirrorNode::ResizeCropMirrorNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ResizeCropMirrorNode::ResizeCropMirrorNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
          Node(inputs, outputs),
         _mirror(MIRROR_RANGE[0], MIRROR_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_crop_mirror.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_crop_mirror.cpp
@@ -39,8 +39,8 @@ void ResizeCropMirrorNode::create_node()
 
     _crop_param->create_array(_graph);
 
-    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().width());
-    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().height_single());
+    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().max_shape()[0]);
+    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().max_shape()[1]);
 
     _dst_roi_width = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
     _dst_roi_height = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
@@ -52,8 +52,8 @@ void ResizeCropMirrorNode::create_node()
     if(width_status != 0 || height_status != 0)
         THROW(" vxAddArrayItems failed in the crop resize node (vxExtrppNode_ResizeCropbatchPD    )  node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
     _mirror.create_array(_graph ,VX_TYPE_UINT32, _batch_size);
-    _node = vxExtrppNode_ResizeCropMirrorPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width,
-                                           _dst_roi_height, _crop_param->x1_arr, _crop_param->x2_arr, _crop_param->y1_arr, _crop_param->y2_arr,  _mirror.default_array(),_batch_size);
+    // _node = vxExtrppNode_ResizeCropMirrorPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width,
+                                        //    _dst_roi_height, _crop_param->x1_arr, _crop_param->x2_arr, _crop_param->y1_arr, _crop_param->y2_arr,  _mirror.default_array(),_batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
@@ -62,7 +62,7 @@ void ResizeCropMirrorNode::create_node()
 
 void ResizeCropMirrorNode::update_node()
 {
-    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi_width_vec(), _inputs[0]->info().get_roi_height_vec());
+    _crop_param->set_image_dimensions(_inputs[0]->info().get_roi());
     _crop_param->update_array();
 }
 

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_mirror_normalize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize_mirror_normalize.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "node_resize_mirror_normalize.h"
 #include "exception.h"
 
-ResizeMirrorNormalizeNode::ResizeMirrorNormalizeNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+ResizeMirrorNormalizeNode::ResizeMirrorNormalizeNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs), _mirror(_mirror_range[0], _mirror_range[1])
 {
 }

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_rotate.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_rotate.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-RotateNode::RotateNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+RotateNode::RotateNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _angle(ROTATE_ANGLE_RANGE[0], ROTATE_ANGLE_RANGE[1])
 {

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_rotate.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_rotate.cpp
@@ -35,8 +35,8 @@ void RotateNode::create_node()
 {
     if(_node)
         return;
-    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().width());
-    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().height_single());
+    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().max_shape()[0]);
+    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().max_shape()[1]);
 
     _dst_roi_width = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
     _dst_roi_height = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
@@ -49,7 +49,7 @@ void RotateNode::create_node()
         THROW(" vxAddArrayItems failed in the resize (vxExtrppNode_ResizebatchPD) node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
 
     _angle.create_array(_graph , VX_TYPE_FLOAT32, _batch_size);
-   _node = vxExtrppNode_RotatebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _angle.default_array(), _batch_size);
+   // _node = vxExtrppNode_RotatebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _angle.default_array(), _batch_size);
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_warp_affine.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_warp_affine.cpp
@@ -58,8 +58,8 @@ void WarpAffineNode::create_node()
     }
     _dst_roi_width = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
     _dst_roi_height = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_UINT32, _batch_size);
-    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().width());
-    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().height_single());
+    std::vector<uint32_t> dst_roi_width(_batch_size,_outputs[0]->info().max_shape()[0]);
+    std::vector<uint32_t> dst_roi_height(_batch_size, _outputs[0]->info().max_shape()[1]);
     width_status = vxAddArrayItems(_dst_roi_width, _batch_size, dst_roi_width.data(), sizeof(vx_uint32));
     height_status = vxAddArrayItems(_dst_roi_height, _batch_size, dst_roi_height.data(), sizeof(vx_uint32));
     if(width_status != 0 || height_status != 0)
@@ -68,8 +68,8 @@ void WarpAffineNode::create_node()
     vx_status status;
     _affine_array = vxCreateArray(vxGetContext((vx_reference)_graph->get()), VX_TYPE_FLOAT32, _batch_size * 6);
     status = vxAddArrayItems(_affine_array,_batch_size * 6, _affine.data(), sizeof(vx_float32));
-    _node = vxExtrppNode_WarpAffinebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height,
-                                           _affine_array, _batch_size);
+    // _node = vxExtrppNode_WarpAffinebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height,
+                                        //    _affine_array, _batch_size);
     
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)
         THROW("Adding the warp affine (vxExtrppNode_WarpAffinePD) node failed: "+ TOSTR(status))

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_warp_affine.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_warp_affine.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "exception.h"
 
 
-WarpAffineNode::WarpAffineNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+WarpAffineNode::WarpAffineNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs),
         _x0(COEFFICIENT_RANGE_1[0], COEFFICIENT_RANGE_1[1]),
         _x1(COEFFICIENT_RANGE_0[0], COEFFICIENT_RANGE_0[1]),

--- a/rocAL/rocAL/source/augmentations/node_copy.cpp
+++ b/rocAL/rocAL/source/augmentations/node_copy.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_copy.h"
 #include "exception.h"
 
-CopyNode::CopyNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+CopyNode::CopyNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs)
 {
 }

--- a/rocAL/rocAL/source/augmentations/node_copy.cpp
+++ b/rocAL/rocAL/source/augmentations/node_copy.cpp
@@ -34,7 +34,7 @@ void CopyNode::create_node()
     if(_node)
         return;
 
-    _node = vxExtrppNode_CopybatchPD(_graph->get(), _inputs[0]->handle(), _outputs[0]->handle());
+    // _node = vxExtrppNode_CopybatchPD(_graph->get(), _inputs[0]->handle(), _outputs[0]->handle());
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/node_nop.cpp
+++ b/rocAL/rocAL/source/augmentations/node_nop.cpp
@@ -35,7 +35,7 @@ void NopNode::create_node()
         return;
 
 
-    _node = vxExtrppNode_NopbatchPD(_graph->get(), _inputs[0]->handle(), _outputs[0]->handle());
+    // _node = vxExtrppNode_NopbatchPD(_graph->get(), _inputs[0]->handle(), _outputs[0]->handle());
 
     vx_status status;
     if((status = vxGetStatus((vx_reference)_node)) != VX_SUCCESS)

--- a/rocAL/rocAL/source/augmentations/node_nop.cpp
+++ b/rocAL/rocAL/source/augmentations/node_nop.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "node_nop.h"
 #include "exception.h"
 
-NopNode::NopNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) :
+NopNode::NopNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) :
         Node(inputs, outputs)
 {
 }

--- a/rocAL/rocAL/source/augmentations/node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/augmentations/node_ssd_random_crop.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "node_ssd_random_crop.h"
 #include "exception.h"
 
-SSDRandomCropNode::SSDRandomCropNode(const std::vector<Image *> &inputs, const std::vector<Image *> &outputs) : Node(inputs, outputs),
+SSDRandomCropNode::SSDRandomCropNode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) : Node(inputs, outputs),
                                                                                                           _dest_width(_outputs[0]->info().width()),
                                                                                                           _dest_height(_outputs[0]->info().height_batch())
 {


### PR DESCRIPTION
- Modify the augmentation nodes in rocAL to fix build issues

1. Change reference from Image to Tensor
2. Comment out the vx_Extrpp calls wrt batchPD (The correct vxExtrpp call for tensor augmentations will be introduced in future PR)
3. Change the API to get the width and height from TensorInfo


- Change the name of the API in OpenVX extensions tensor augmentation files wrt latest changes in the Opensource TOT develop

