### PR TITLE
rocAL ROI changes

### DIFF
--- a/rocAL/rocAL/include/pipeline/ring_buffer.h
+++ b/rocAL/rocAL/include/pipeline/ring_buffer.h
@@ -45,12 +45,14 @@ public:
     ///\param dev
     ///\param sub_buffer_size
     ///\param sub_buffer_count
-    void init(RocalMemType mem_type, void *dev, std::vector<size_t> &sub_buffer_size);
+    void init(RocalMemType mem_type, void *dev, std::vector<size_t> &sub_buffer_size, size_t roi_buffer_size);
     void initBoxEncoderMetaData(RocalMemType mem_type, size_t encoded_bbox_size, size_t encoded_labels_size);
     void init_metadata(RocalMemType mem_type, std::vector<size_t> &sub_buffer_size);
     void release_gpu_res();
     std::vector<void*> get_read_buffers();
     std::vector<void*> get_write_buffers();
+    std::vector<unsigned*> get_read_roi_buffers();
+    std::vector<unsigned*> get_write_roi_buffers();
     std::pair<void*, void*> get_box_encode_write_buffers();
     std::pair<void*, void*> get_box_encode_read_buffers();
     MetaDataNamePair& get_meta_data();
@@ -84,6 +86,8 @@ private:
     std::condition_variable _wait_for_unload;
     std::vector<std::vector<void*>> _dev_sub_buffer;
     std::vector<std::vector<void*>> _host_sub_buffers;
+    std::vector<std::vector<unsigned *>> _dev_roi_buffers;
+    std::vector<std::vector<unsigned *>> _host_roi_buffers;
     std::vector<std::vector<void*>> _host_meta_data_buffers;
     std::vector<void *> _dev_bbox_buffer;
     std::vector<void *> _dev_labels_buffer;

--- a/rocAL/rocAL/include/pipeline/ring_buffer.h
+++ b/rocAL/rocAL/include/pipeline/ring_buffer.h
@@ -49,10 +49,8 @@ public:
     void initBoxEncoderMetaData(RocalMemType mem_type, size_t encoded_bbox_size, size_t encoded_labels_size);
     void init_metadata(RocalMemType mem_type, std::vector<size_t> &sub_buffer_size);
     void release_gpu_res();
-    std::vector<void*> get_read_buffers();
-    std::vector<void*> get_write_buffers();
-    std::vector<unsigned*> get_read_roi_buffers();
-    std::vector<unsigned*> get_write_roi_buffers();
+    std::pair<std::vector<void *>, std::vector<unsigned *>> get_read_buffers();
+    std::pair<std::vector<void *>, std::vector<unsigned *>> get_write_buffers();
     std::pair<void*, void*> get_box_encode_write_buffers();
     std::pair<void*, void*> get_box_encode_read_buffers();
     MetaDataNamePair& get_meta_data();

--- a/rocAL/rocAL/include/pipeline/tensor.h
+++ b/rocAL/rocAL/include/pipeline/tensor.h
@@ -183,6 +183,11 @@ public:
     bool is_image() const { return _is_image; }
     void set_metadata() { _is_metadata = true; }
     bool is_metadata() const { return _is_metadata; }
+    void swap_roi_ptr(std::shared_ptr<unsigned> &ptr) { _roi.swap(ptr); }
+    void copy_roi(void *roi_buffer) {
+        if(_roi != nullptr && roi_buffer != nullptr)
+            memcpy((void *)roi_buffer, (const void *)_roi.get(), _batch_size * sizeof(RocalROI));
+    }
 
 private:
     Type _type = Type::UNKNOWN;  //!< tensor type, whether is virtual tensor, created from handle or is a regular tensor
@@ -237,6 +242,8 @@ public:
     int create(vx_context context);
     void update_tensor_roi(const std::vector<uint32_t>& width, const std::vector<uint32_t>& height);
     void reset_tensor_roi() { _info.reset_tensor_roi_buffers(); }
+    void swap_tensor_roi(std::shared_ptr<unsigned> &roi_ptr) { _info.swap_roi_ptr(roi_ptr); }
+    void copy_roi(void *roi_buffer) { _info.copy_roi(roi_buffer); }
     // create_from_handle() no internal memory allocation is done here since
     // tensor's handle should be swapped with external buffers before usage
     int create_from_handle(vx_context context);

--- a/rocAL/rocAL/include/pipeline/tensor.h
+++ b/rocAL/rocAL/include/pipeline/tensor.h
@@ -81,9 +81,6 @@ public:
     TensorInfo(std::vector<size_t> dims, RocalMemType mem_type,
                     RocalTensorDataType data_type);
 
-    //! Copy constructor
-    TensorInfo(const TensorInfo& info);
-    ~TensorInfo();
     // Setting properties required for Image / Video
     void set_roi_type(RocalROIType roi_type) { _roi_type = roi_type; }
     void set_data_type(RocalTensorDataType data_type) {
@@ -176,7 +173,7 @@ public:
     RocalROIType roi_type() const { return _roi_type; }
     RocalTensorDataType data_type() const { return _data_type; }
     RocalTensorlayout layout() const { return _layout; }
-    RocalROI *get_roi() const { return (RocalROI *)_roi_buf; }
+    RocalROI *get_roi() const { return (RocalROI *)_roi.get(); }
     RocalColorFormat color_format() const { return _color_format; }
     Type type() const { return _type; }
     uint64_t data_type_size() {
@@ -198,7 +195,8 @@ private:
     RocalTensorDataType _data_type = RocalTensorDataType::FP32;  //!< tensor data type
     RocalTensorlayout _layout = RocalTensorlayout::NONE;     //!< layout of the tensor
     RocalColorFormat _color_format;  //!< color format of the image
-    void *_roi_buf = nullptr;
+    unsigned *_roi_buf = nullptr;
+    std::shared_ptr<unsigned> _roi;
     uint64_t _data_type_size = tensor_data_size(_data_type);
     uint64_t _data_size = 0;
     std::vector<size_t> _max_shape;  //!< stores the the width and height dimensions in the tensor

--- a/rocAL/rocAL/include/pipeline/tensor.h
+++ b/rocAL/rocAL/include/pipeline/tensor.h
@@ -183,7 +183,10 @@ public:
     bool is_image() const { return _is_image; }
     void set_metadata() { _is_metadata = true; }
     bool is_metadata() const { return _is_metadata; }
-    void swap_roi_ptr(std::shared_ptr<unsigned> &ptr) { _roi.swap(ptr); }
+    void set_roi_ptr(unsigned *roi_ptr) { 
+        auto deleter = [&](unsigned *ptr) {};   // Empty destructor used, since memory is handled by the pipeline
+        _roi.reset(roi_ptr, deleter); 
+    }
     void copy_roi(void *roi_buffer) {
         if(_roi != nullptr && roi_buffer != nullptr)
             memcpy((void *)roi_buffer, (const void *)_roi.get(), _batch_size * sizeof(RocalROI));
@@ -242,7 +245,7 @@ public:
     int create(vx_context context);
     void update_tensor_roi(const std::vector<uint32_t>& width, const std::vector<uint32_t>& height);
     void reset_tensor_roi() { _info.reset_tensor_roi_buffers(); }
-    void swap_tensor_roi(std::shared_ptr<unsigned> &roi_ptr) { _info.swap_roi_ptr(roi_ptr); }
+    void set_roi(unsigned *roi_ptr) { _info.set_roi_ptr(roi_ptr); }
     void copy_roi(void *roi_buffer) { _info.copy_roi(roi_buffer); }
     // create_from_handle() no internal memory allocation is done here since
     // tensor's handle should be swapped with external buffers before usage

--- a/rocAL/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/rocAL/source/pipeline/master_graph.cpp
@@ -961,8 +961,8 @@ void MasterGraph::output_routine()
             }
             _rb_block_if_full_time.start();
             // _ring_buffer.get_write_buffers() is blocking and blocks here until user uses processed image by calling run() and frees space in the ring_buffer
-            auto write_output_buffers = _ring_buffer.get_write_buffers();
-            auto write_buffers = write_output_buffers.first;
+            auto write_buffers = _ring_buffer.get_write_buffers();
+            auto write_output_buffers = write_buffers.first;
             _rb_block_if_full_time.end();
 
             // Swap handles on the input tensor, so that new tensor is loaded to be processed
@@ -987,7 +987,7 @@ void MasterGraph::output_routine()
 
             // Swap handles on the output tensor, so that new processed tensor will be written to the a new buffer
             for (size_t idx = 0; idx < _internal_tensor_list.size(); idx++)
-                _internal_tensor_list[idx]->swap_handle(write_buffers[idx]);
+                _internal_tensor_list[idx]->swap_handle(write_output_buffers[idx]);
 
             if (!_processing)
                 break;
@@ -1019,9 +1019,9 @@ void MasterGraph::output_routine()
             _graph->process();
             _process_time.end();
 
-            auto tensor_roi_buffer = write_output_buffers.second;   // Obtain ROI buffers from ring buffer
+            auto write_roi_buffers = write_buffers.second;   // Obtain ROI buffers from ring buffer
             for (size_t idx = 0; idx < _internal_tensor_list.size(); idx++)
-                _internal_tensor_list[idx]->copy_roi(tensor_roi_buffer[idx]);   // Copy ROI from internal tensor's buffer to ring buffer
+                _internal_tensor_list[idx]->copy_roi(write_roi_buffers[idx]);   // Copy ROI from internal tensor's buffer to ring buffer
             _bencode_time.start();
             if(_is_box_encoder )
             {

--- a/rocAL/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/rocAL/source/pipeline/master_graph.cpp
@@ -288,9 +288,9 @@ MasterGraph::build()
         THROW("No output tensors are there, cannot create the pipeline")
 
 #if ENABLE_HIP || ENABLE_OPENCL
-    _ring_buffer.init(_mem_type, (void *)_device.resources(), _internal_tensor_list.data_size());
+    _ring_buffer.init(_mem_type, (void *)_device.resources(), _internal_tensor_list.data_size(), _user_batch_size * sizeof(RocalROI));
 #else
-    _ring_buffer.init(_mem_type, nullptr, _internal_tensor_list.data_size());
+    _ring_buffer.init(_mem_type, nullptr, _internal_tensor_list.data_size(), _user_batch_size * sizeof(RocalROI));
 #endif
     if (_is_box_encoder) _ring_buffer.initBoxEncoderMetaData(_mem_type, _user_batch_size*_num_anchors*4*sizeof(float), _user_batch_size*_num_anchors*sizeof(int));
     create_single_graph();
@@ -934,9 +934,16 @@ TensorList *
 MasterGraph::get_output_tensors()
 {
     auto output_ptr = _ring_buffer.get_read_buffers();
+    std::vector<unsigned* > roi_ptr = _ring_buffer.get_read_roi_buffers();
+    // TODO - check here if size of internal tensor and ring buffer is same?
+    auto deleter=[&](unsigned* ptr){ };
     for(unsigned i = 0; i < _internal_tensor_list.size(); i++)
+    {
+        std::shared_ptr<unsigned> roi_ptr_sh;
+        roi_ptr_sh.reset(roi_ptr[i], deleter);
         _output_tensor_list[i]->set_mem_handle(output_ptr[i]);
-    
+        _output_tensor_list[i]->swap_tensor_roi(roi_ptr_sh);
+    }
     return &_output_tensor_list;
 }
 
@@ -959,6 +966,7 @@ void MasterGraph::output_routine()
             _rb_block_if_full_time.start();
             // _ring_buffer.get_write_buffers() is blocking and blocks here until user uses processed image by calling run() and frees space in the ring_buffer
             auto write_buffers = _ring_buffer.get_write_buffers();
+            auto tensor_roi_buffer = _ring_buffer.get_write_roi_buffers();
             _rb_block_if_full_time.end();
 
             // Swap handles on the input tensor, so that new tensor is loaded to be processed
@@ -1014,6 +1022,8 @@ void MasterGraph::output_routine()
             _process_time.start();
             _graph->process();
             _process_time.end();
+            for (size_t idx = 0; idx < _internal_tensor_list.size(); idx++)
+                _internal_tensor_list[idx]->copy_roi(tensor_roi_buffer[idx]);
             _bencode_time.start();
             if(_is_box_encoder )
             {

--- a/rocAL/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/rocAL/source/pipeline/master_graph.cpp
@@ -532,7 +532,7 @@ MasterGraph::to_tensor(void *out_ptr, RocalTensorlayout format, float multiplier
         cl_kernel kernel = _device["utility"][kernel_name];
         auto queue = _device.resources()->cmd_queue;
         unsigned dest_buf_offset = 0;
-        auto output_buffers =_ring_buffer.get_read_buffers();
+        auto output_buffers = _ring_buffer.get_read_buffers().first;
 
         if(_output_tensor_buffer == nullptr) {
             size_t size = output_tensor_info.data_size() * sizeof(cl_float);
@@ -591,7 +591,7 @@ MasterGraph::to_tensor(void *out_ptr, RocalTensorlayout format, float multiplier
     {
         unsigned int fp16 = (output_data_type == RocalTensorDataType::FP16);
 
-        auto output_buffers =_ring_buffer.get_read_buffers();
+        auto output_buffers = _ring_buffer.get_read_buffers().first;
         unsigned dest_buf_offset = 0;
         // copy hip buffer to out_ptr
         // todo:: add callback routing to exchange memory pointer to avoid extra copy
@@ -617,7 +617,7 @@ MasterGraph::to_tensor(void *out_ptr, RocalTensorlayout format, float multiplier
         {
             unsigned int fp16 = (output_data_type == RocalTensorDataType::FP16);
 
-            auto output_buffers =_ring_buffer.get_read_buffers();
+            auto output_buffers = _ring_buffer.get_read_buffers().first;
             unsigned dest_buf_offset = 0;
             
             if(_output_tensor_buffer == nullptr) {
@@ -664,7 +664,7 @@ MasterGraph::to_tensor(void *out_ptr, RocalTensorlayout format, float multiplier
             float offset[3] = {offset0, offset1, offset2};
             size_t dest_buf_offset_start = 0;
 
-            auto output_buffers =_ring_buffer.get_read_buffers();
+            auto output_buffers = _ring_buffer.get_read_buffers().first;
             auto num_threads = _cpu_num_threads * 2;
             for( auto&& out_tensor: output_buffers)
             {
@@ -878,7 +878,7 @@ MasterGraph::copy_output(unsigned char *out_ptr, size_t out_size_in_bytes)
         // to avoid unnecessary sequence of synchronizations
 
         // get_read_buffers() calls block_if_empty() internally and blocks if buffers are empty until a new batch is processed
-        auto output_buffers = _ring_buffer.get_read_buffers();
+        auto output_buffers = _ring_buffer.get_read_buffers().first;
         auto out_image_idx = output_buffers.size();
         for( auto&& output_handle: output_buffers)
         {
@@ -904,7 +904,7 @@ MasterGraph::copy_output(unsigned char *out_ptr, size_t out_size_in_bytes)
 
         // get_read_buffers() calls block_if_empty() internally and blocks if buffers are empty until a new batch is processed
         size_t dest_buf_offset = 0;
-        auto output_buffers =_ring_buffer.get_read_buffers();
+        auto output_buffers = _ring_buffer.get_read_buffers().first;
         for( auto&& output_handle: output_buffers)
         {
             hipError_t err = hipMemcpyDtoHAsync((void *)(out_ptr + dest_buf_offset), output_handle, size, _device.resources()->hip_stream);
@@ -933,16 +933,12 @@ MasterGraph::copy_output(unsigned char *out_ptr, size_t out_size_in_bytes)
 TensorList *
 MasterGraph::get_output_tensors()
 {
-    auto output_ptr = _ring_buffer.get_read_buffers();
-    std::vector<unsigned* > roi_ptr = _ring_buffer.get_read_roi_buffers();
-    // TODO - check here if size of internal tensor and ring buffer is same?
-    auto deleter=[&](unsigned* ptr){ };
-    for(unsigned i = 0; i < _internal_tensor_list.size(); i++)
-    {
-        std::shared_ptr<unsigned> roi_ptr_sh;
-        roi_ptr_sh.reset(roi_ptr[i], deleter);
+    auto read_buffers = _ring_buffer.get_read_buffers().first;
+    auto output_ptr = read_buffers.first;
+    auto roi_ptr = read_buffers.second;
+    for(unsigned i = 0; i < _internal_tensor_list.size(); i++) {
         _output_tensor_list[i]->set_mem_handle(output_ptr[i]);
-        _output_tensor_list[i]->swap_tensor_roi(roi_ptr_sh);
+        _output_tensor_list[i]->set_roi(roi_ptr[i]);
     }
     return &_output_tensor_list;
 }
@@ -965,8 +961,8 @@ void MasterGraph::output_routine()
             }
             _rb_block_if_full_time.start();
             // _ring_buffer.get_write_buffers() is blocking and blocks here until user uses processed image by calling run() and frees space in the ring_buffer
-            auto write_buffers = _ring_buffer.get_write_buffers();
-            auto tensor_roi_buffer = _ring_buffer.get_write_roi_buffers();
+            auto write_output_buffers = _ring_buffer.get_write_buffers();
+            auto write_buffers = write_output_buffers.first;
             _rb_block_if_full_time.end();
 
             // Swap handles on the input tensor, so that new tensor is loaded to be processed
@@ -1022,8 +1018,10 @@ void MasterGraph::output_routine()
             _process_time.start();
             _graph->process();
             _process_time.end();
+
+            auto tensor_roi_buffer = write_output_buffers.second;   // Obtain ROI buffers from ring buffer
             for (size_t idx = 0; idx < _internal_tensor_list.size(); idx++)
-                _internal_tensor_list[idx]->copy_roi(tensor_roi_buffer[idx]);
+                _internal_tensor_list[idx]->copy_roi(tensor_roi_buffer[idx]);   // Copy ROI from internal tensor's buffer to ring buffer
             _bencode_time.start();
             if(_is_box_encoder )
             {
@@ -1554,7 +1552,7 @@ MasterGraph::copy_out_tensor_planar(void *out_ptr, RocalTensorlayout format, flo
         float offset[3] = {offset0, offset1, offset2 };
         size_t dest_buf_offset = 0;
 
-        auto output_buffers = _ring_buffer.get_read_buffers();
+        auto output_buffers = _ring_buffer.get_read_buffers().first;
 
         for( auto&& out_tensor: output_buffers)
         {

--- a/rocAL/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/rocAL/source/pipeline/master_graph.cpp
@@ -921,7 +921,7 @@ MasterGraph::copy_output(unsigned char *out_ptr, size_t out_size_in_bytes)
     else {
 #endif
         // get_read_buffer is blocking if _ring_buffer is empty, and blocks this thread till internal processing thread process a new batch and store in the _ring_buffer
-        auto output_buffer = _ring_buffer.get_read_buffers()[0];
+        auto output_buffer = _ring_buffer.get_read_buffers().first[0];
         memcpy(out_ptr, output_buffer, size);
 #if ENABLE_OPENCL || ENABLE_HIP
     }
@@ -933,7 +933,7 @@ MasterGraph::copy_output(unsigned char *out_ptr, size_t out_size_in_bytes)
 TensorList *
 MasterGraph::get_output_tensors()
 {
-    auto read_buffers = _ring_buffer.get_read_buffers().first;
+    auto read_buffers = _ring_buffer.get_read_buffers();
     auto output_ptr = read_buffers.first;
     auto roi_ptr = read_buffers.second;
     for(unsigned i = 0; i < _internal_tensor_list.size(); i++) {

--- a/rocAL/rocAL/source/pipeline/ring_buffer.cpp
+++ b/rocAL/rocAL/source/pipeline/ring_buffer.cpp
@@ -57,20 +57,14 @@ void RingBuffer:: block_if_full()
         _wait_for_unload.wait(lock);
     }
 }
-std::vector<void*> RingBuffer::get_read_buffers()
-{
-    block_if_empty();
-    if((_mem_type == RocalMemType::OCL) || (_mem_type == RocalMemType::HIP))
-        return _dev_sub_buffer[_read_ptr];
-    return _host_sub_buffers[_read_ptr];
-}
 
-std::vector<unsigned*> RingBuffer::get_read_roi_buffers()
+std::pair<std::vector<void*>, std::vector<unsigned*>> RingBuffer::get_read_buffers()
 {
     block_if_empty();
     if((_mem_type == RocalMemType::OCL) || (_mem_type == RocalMemType::HIP))
-        return _dev_roi_buffers[_read_ptr];
-    return _host_roi_buffers[_read_ptr];
+        return std::make_pair(_dev_sub_buffer[_read_ptr], _dev_roi_buffers[_read_ptr]);
+
+    return std::make_pair(_host_sub_buffers[_read_ptr], _host_roi_buffers[_read_ptr]);
 }
 
 std::pair<void*, void*> RingBuffer::get_box_encode_read_buffers()
@@ -81,22 +75,13 @@ std::pair<void*, void*> RingBuffer::get_box_encode_read_buffers()
     return std::make_pair(_host_meta_data_buffers[_read_ptr][1], _host_meta_data_buffers[_read_ptr][0]);
 }
 
-std::vector<void*> RingBuffer::get_write_buffers()
+std::pair<std::vector<void*>, std::vector<unsigned*>> RingBuffer::get_write_buffers()
 {
     block_if_full();
     if((_mem_type == RocalMemType::OCL) || (_mem_type == RocalMemType::HIP))
-        return _dev_sub_buffer[_write_ptr];
+        return std::make_pair(_dev_sub_buffer[_write_ptr], _dev_roi_buffers[_write_ptr]);
 
-    return _host_sub_buffers[_write_ptr];
-}
-
-std::vector<unsigned*> RingBuffer::get_write_roi_buffers()
-{
-    block_if_full();
-    if((_mem_type == RocalMemType::OCL) || (_mem_type == RocalMemType::HIP))
-        return _dev_roi_buffers[_write_ptr];
-
-    return _host_roi_buffers[_write_ptr];
+    return std::make_pair(_host_sub_buffers[_write_ptr], _host_roi_buffers[_write_ptr]);
 }
 
 std::pair<void*, void*> RingBuffer::get_box_encode_write_buffers()

--- a/rocAL/rocAL/source/pipeline/ring_buffer.cpp
+++ b/rocAL/rocAL/source/pipeline/ring_buffer.cpp
@@ -352,10 +352,11 @@ void RingBuffer::release_gpu_res()
                         //printf("Error Freeing device buffer <%d, %d, %p>\n", buffIdx, sub_buf_idx, _dev_sub_buffer[buffIdx][sub_buf_idx]);
                         ERR("Could not release hip memory in the ring buffer")
                     }
-                if (_dev_roi_buffers[buffIdx][sub_buf_idx])
-                    if ( hipHostFree((void *)_dev_roi_buffers[buffIdx][sub_buf_idx]) != hipSuccess ) {
+                if (_dev_roi_buffers[buffIdx][sub_buf_idx]) {
+                    if (hipHostFree((void *)_dev_roi_buffers[buffIdx][sub_buf_idx]) != hipSuccess) {
                         ERR("Could not release hip memory for ROI in the ring buffer")
                     }
+                }
             }
             if(_host_meta_data_buffers.size() != 0) {
                 for (unsigned sub_buf_idx = 0; sub_buf_idx < _host_meta_data_buffers[buffIdx].size(); sub_buf_idx++) {

--- a/rocAL/rocAL/source/pipeline/ring_buffer.cpp
+++ b/rocAL/rocAL/source/pipeline/ring_buffer.cpp
@@ -27,10 +27,10 @@ RingBuffer::RingBuffer(unsigned buffer_depth):
         BUFF_DEPTH(buffer_depth),
         _dev_sub_buffer(buffer_depth),
         _host_sub_buffers(buffer_depth),
-        _dev_bbox_buffer(buffer_depth),
-        _dev_labels_buffer(buffer_depth),
         _dev_roi_buffers(buffer_depth),
-        _host_roi_buffers(buffer_depth)
+        _host_roi_buffers(buffer_depth),
+        _dev_bbox_buffer(buffer_depth),
+        _dev_labels_buffer(buffer_depth)
 {
     reset();
 }

--- a/rocAL/rocAL/source/pipeline/tensor.cpp
+++ b/rocAL/rocAL/source/pipeline/tensor.cpp
@@ -107,7 +107,7 @@ bool operator==(const TensorInfo &rhs, const TensorInfo &lhs) {
 }
 
 
-void rocalTensorInfo::reset_tensor_roi_buffers() {
+void TensorInfo::reset_tensor_roi_buffers() {
     size_t roi_size = (_layout == RocalTensorlayout::NFCHW || _layout == RocalTensorlayout::NFHWC) ? _dims[0] * _dims[1] : _batch_size; // For Sequences pre allocating the ROI to N * F to replicate in OpenVX extensions
     allocate_host_or_pinned_mem((void **)&_roi_buf, roi_size * 4 * sizeof(unsigned), _mem_type);
     if (_mem_type == RocalMemType::HIP) {

--- a/rocAL/rocAL/source/pipeline/tensor.cpp
+++ b/rocAL/rocAL/source/pipeline/tensor.cpp
@@ -107,10 +107,15 @@ bool operator==(const TensorInfo &rhs, const TensorInfo &lhs) {
 }
 
 
-void TensorInfo::reset_tensor_roi_buffers() {
-    if(!_roi_buf) {
-        size_t roi_size = (_layout == RocalTensorlayout::NFCHW || _layout == RocalTensorlayout::NFHWC) ? _dims[0] * _dims[1] : _batch_size; // For Sequences pre allocating the ROI to N * F to replicate in OpenVX extensions
-        allocate_host_or_pinned_mem((void **)&_roi_buf, roi_size * 4 * sizeof(unsigned), _mem_type);
+void rocalTensorInfo::reset_tensor_roi_buffers() {
+    size_t roi_size = (_layout == RocalTensorlayout::NFCHW || _layout == RocalTensorlayout::NFHWC) ? _dims[0] * _dims[1] : _batch_size; // For Sequences pre allocating the ROI to N * F to replicate in OpenVX extensions
+    allocate_host_or_pinned_mem((void **)&_roi_buf, roi_size * 4 * sizeof(unsigned), _mem_type);
+    if (_mem_type == RocalMemType::HIP) {
+#if ENABLE_HIP
+        _roi.reset(_roi_buf, hipHostFree);
+#endif
+    } else {
+        _roi.reset(_roi_buf, free);
     }
     if (_is_image) {
         auto roi = get_roi();
@@ -147,46 +152,6 @@ TensorInfo::TensorInfo(std::vector<size_t> dims,
     _data_size = _strides[0] * dims[0];
 
     if (_num_of_dims <= 3) _is_image = false;
-}
-
-TensorInfo::TensorInfo(const TensorInfo &other) {
-    _type = other._type;
-    _num_of_dims = other._num_of_dims;
-    _dims = other._dims;
-    _strides = other._strides;
-    _batch_size = other._batch_size;
-    _mem_type = other._mem_type;
-    _roi_type = other._roi_type;
-    _data_type = other._data_type;
-    _layout = other._layout;
-    _color_format = other._color_format;
-    _data_type_size = other._data_type_size;
-    _data_size = other._data_size;
-    _max_shape = other._max_shape;
-    _is_image = other._is_image;
-    _is_metadata = other._is_metadata;
-    _channels = other._channels;
-    if(!other.is_metadata()) {  // For Metadata ROI buffer is not required
-        allocate_host_or_pinned_mem(&_roi_buf, _batch_size * 4 * sizeof(unsigned), _mem_type);
-        memcpy((void *)_roi_buf, (const void *)other.get_roi(), _batch_size * 4 * sizeof(unsigned));
-    }
-}
-
-TensorInfo::~TensorInfo() {
-    if(!_is_metadata) {
-        if(_mem_type == RocalMemType::HIP) {
-#if ENABLE_HIP
-            if(_roi_buf) {
-                hipError_t err = hipHostFree(_roi_buf);
-                if (err != hipSuccess)
-                    ERR("hipHostFree failed " + TOSTR(err));
-            }
-#endif
-        } else {
-            if(_roi_buf) free(_roi_buf);
-        }
-        _roi_buf = nullptr;
-    } 
 }
 
 void Tensor::update_tensor_roi(const std::vector<uint32_t> &width,


### PR DESCRIPTION
- Make ROI as shared pointer in TensorInfo
- Remove the constructor and destructor
- Add support to allocate ROI buffers in the ring buffer
- Add changes to copy ROI into ring buffer and return the right ROI buffer to the user